### PR TITLE
chore: bump version to 2.0.3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+golang-github-linuxdeepin-go-dbus-factory (2.0.3) unstable; urgency=medium
+
+  [ TagBuilder ]
+  * chore: archlinux打包目录存在问题
+
+ -- dengbo <dengbo@uniontech.com>  Wed, 29 Mar 2023 16:33:32 +0800
+
 golang-github-linuxdeepin-go-dbus-factory (2.0.2) unstable; urgency=medium
 
   [ TagBuilder ]


### PR DESCRIPTION
Changelog

  * release go-dbus-factory 2.0.3

Log: