### PR TITLE
chore: release go-dbus-factory 2.0.7

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+golang-github-linuxdeepin-go-dbus-factory (2.0.7) unstable; urgency=medium
+
+  * add new am dbus interface
+
+ -- dengbo <dengbo@deepin.org>  Mon, 06 Nov 2023 16:03:20 +0800
+
 golang-github-linuxdeepin-go-dbus-factory (2.0.6) unstable; urgency=medium
 
   * use new am interface instead


### PR DESCRIPTION
release go-dbus-factory 2.0.7

Log: