### PR TITLE
chore: release go-dbus-factory 2.0.11

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+golang-github-linuxdeepin-go-dbus-factory (2.0.11) unstable; urgency=medium
+
+  * fix(audio): 添加日历接口的调
+
+ -- fuleyi <fuleyi@uniontech.com>  Thu, 05 Dec 2024 14:09:19 +0800
+
 golang-github-linuxdeepin-go-dbus-factory (2.0.10) unstable; urgency=medium
 
   * chore: 更正bluez属性Percentage为byte (#119)


### PR DESCRIPTION
release go-dbus-factory 2.0.11