### PR TITLE
chore: release go-dbus-factory 2.0.12

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+golang-github-linuxdeepin-go-dbus-factory (2.0.12) unstable; urgency=medium
+
+  * chore: add org.deepin.dde.grub2
+
+ -- fuleyi <fuleyi@uniontech.com>  Tue, 22 Apr 2025 21:29:59 +0800
+
 golang-github-linuxdeepin-go-dbus-factory (2.0.11) unstable; urgency=medium
 
   * fix(audio): 添加日历接口的调


### PR DESCRIPTION
release go-dbus-factory 2.0.12