### PR TITLE
feat: add isDefaultValue method to ConfigManager

### DIFF
--- a/org.desktopspec.ConfigManager/Manager.xml
+++ b/org.desktopspec.ConfigManager/Manager.xml
@@ -12,6 +12,10 @@
       <arg direction="in" type="s" name="key"/>
       <arg direction="in" type="v" name="value"/>
     </method>
+    <method name="isDefaultValue">
+      <arg direction="in" type="s" name="key"/>
+      <arg direction="out" type="b" name="isDefault"/>
+    </method>
     <method name="reset">
       <arg direction="in" type="s" name="key"/>
     </method>

--- a/org.desktopspec.ConfigManager/auto.go
+++ b/org.desktopspec.ConfigManager/auto.go
@@ -140,6 +140,8 @@ type manager interface {
 	Value(flags dbus.Flags, key string) (dbus.Variant, error)
 	GoSetValue(flags dbus.Flags, ch chan *dbus.Call, key string, value dbus.Variant) *dbus.Call
 	SetValue(flags dbus.Flags, key string, value dbus.Variant) error
+	GoIsDefaultValue(flags dbus.Flags, ch chan *dbus.Call, key string) *dbus.Call
+	IsDefaultValue(flags dbus.Flags, key string) (bool, error)
 	GoReset(flags dbus.Flags, ch chan *dbus.Call, key string) *dbus.Call
 	Reset(flags dbus.Flags, key string) error
 	GoName(flags dbus.Flags, ch chan *dbus.Call, key string, language string) *dbus.Call
@@ -193,6 +195,22 @@ func (v *interfaceManager) GoSetValue(flags dbus.Flags, ch chan *dbus.Call, key 
 
 func (v *interfaceManager) SetValue(flags dbus.Flags, key string, value dbus.Variant) error {
 	return (<-v.GoSetValue(flags, make(chan *dbus.Call, 1), key, value).Done).Err
+}
+
+// method isDefaultValue
+
+func (v *interfaceManager) GoIsDefaultValue(flags dbus.Flags, ch chan *dbus.Call, key string) *dbus.Call {
+	return v.GetObject_().Go_(v.GetInterfaceName_()+".isDefaultValue", flags, ch, key)
+}
+
+func (*interfaceManager) StoreIsDefaultValue(call *dbus.Call) (isDefault bool, err error) {
+	err = call.Store(&isDefault)
+	return
+}
+
+func (v *interfaceManager) IsDefaultValue(flags dbus.Flags, key string) (bool, error) {
+	return v.StoreIsDefaultValue(
+		<-v.GoIsDefaultValue(flags, make(chan *dbus.Call, 1), key).Done)
 }
 
 // method reset

--- a/org.desktopspec.ConfigManager/auto_mock.go
+++ b/org.desktopspec.ConfigManager/auto_mock.go
@@ -180,6 +180,25 @@ func (v *MockInterfaceManager) SetValue(flags dbus.Flags, key string, value dbus
 	return mockArgs.Error(0)
 }
 
+// method isDefaultValue
+
+func (v *MockInterfaceManager) GoIsDefaultValue(flags dbus.Flags, ch chan *dbus.Call, key string) *dbus.Call {
+	mockArgs := v.Called(flags, ch, key)
+
+	ret, ok := mockArgs.Get(0).(*dbus.Call)
+	if !ok {
+		panic(fmt.Sprintf("assert: arguments: 0 failed because object wasn't correct type: %v", mockArgs.Get(0)))
+	}
+
+	return ret
+}
+
+func (v *MockInterfaceManager) IsDefaultValue(flags dbus.Flags, key string) (bool, error) {
+	mockArgs := v.Called(flags, key)
+
+	return mockArgs.Bool(0), mockArgs.Error(1)
+}
+
 // method reset
 
 func (v *MockInterfaceManager) GoReset(flags dbus.Flags, ch chan *dbus.Call, key string) *dbus.Call {


### PR DESCRIPTION
1. Added new D-Bus method isDefaultValue in Manager.xml interface definition
2. Implemented corresponding Go methods in auto.go including GoIsDefaultValue and IsDefaultValue
3. Added mock implementation in auto_mock.go for testing purposes
4. The new method allows checking if a configuration value is set to its default state

feat: 在ConfigManager中添加isDefaultValue方法

1. 在Manager.xml接口定义中添加新的D-Bus方法isDefaultValue
2. 在auto.go中实现对应的Go方法包括GoIsDefaultValue和IsDefaultValue
3. 在auto_mock.go中添加模拟实现用于测试
4. 新方法允许检查配置值是否处于默认状态

pms: BUG-315181