### PR TITLE
chore: bump version to 2.0.17

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+golang-github-linuxdeepin-go-dbus-factory (2.0.17) unstable; urgency=medium
+
+  * chore: update 1st-party dependency in go.mod and go.sum
+
+ -- fuleyi <fuleyi@uniontech.com>  Fri, 15 Aug 2025 09:03:42 +0800
+
 golang-github-linuxdeepin-go-dbus-factory (2.0.16) unstable; urgency=medium
 
   * Release 2.0.16


### PR DESCRIPTION
update changelog to 2.0.17