### PR TITLE
chore: bump version to 2.0.19

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+golang-github-linuxdeepin-go-dbus-factory (2.0.19) unstable; urgency=medium
+
+  * feat: 添加控制中心接口
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Fri, 19 Sep 2025 10:53:02 +0800
+
 golang-github-linuxdeepin-go-dbus-factory (2.0.18) unstable; urgency=medium
 
   * feat: 多屏场景下支持合盖后自动切换仅外屏显示


### PR DESCRIPTION
update changelog to 2.0.19