### PR TITLE
feat: add finger-needed property to fprint device interface

### DIFF
--- a/system/net.reactivated.fprint/Device.xml
+++ b/system/net.reactivated.fprint/Device.xml
@@ -62,5 +62,6 @@
     <property name="scan-type" type="s" access="read"/>
     <property name="num-enroll-stages" type="i" access="read"/>
     <property name="name" type="s" access="read"/>
-  </interface>
+    <property name="finger-needed" type="b" access="read"/>
+     </interface>
 </node>

--- a/system/net.reactivated.fprint/auto.go
+++ b/system/net.reactivated.fprint/auto.go
@@ -141,6 +141,7 @@ type device interface {
 	ScanType() proxy.PropString
 	NumEnrollStages() proxy.PropInt32
 	Name() proxy.PropString
+	FingerNeeded() proxy.PropBool
 }
 
 type interfaceDevice struct{}
@@ -353,5 +354,14 @@ func (v *interfaceDevice) Name() proxy.PropString {
 	return &proxy.ImplPropString{
 		Impl: v,
 		Name: "name",
+	}
+}
+
+// property finger-needed b
+
+func (v *interfaceDevice) FingerNeeded() proxy.PropBool {
+	return &proxy.ImplPropBool{
+		Impl: v,
+		Name: "finger-needed",
 	}
 }

--- a/system/net.reactivated.fprint/auto_mock.go
+++ b/system/net.reactivated.fprint/auto_mock.go
@@ -339,3 +339,16 @@ func (v *MockInterfaceDevice) Name() proxy.PropString {
 
 	return ret0
 }
+
+// property finger-needed b
+
+func (v *MockInterfaceDevice) FingerNeeded() proxy.PropBool {
+	mockArgs := v.Called()
+
+	ret0, ok := mockArgs.Get(0).(*proxy.MockPropBool)
+	if !ok {
+		panic(fmt.Sprintf("assert: arguments: %d failed because object wasn't correct type: %v", 0, mockArgs.Get(0)))
+	}
+
+	return ret0
+}

--- a/system/net.reactivated.fprint/config.json
+++ b/system/net.reactivated.fprint/config.json
@@ -36,6 +36,9 @@
             },
             "p/name": {
               "RenameTo": "Name"
+            },
+            "p/finger-needed": {
+              "RenameTo": "FingerNeeded"
             }
           }
         }


### PR DESCRIPTION
Added a new read-only boolean property 'finger-needed' to the fingerprint device D-Bus interface. This property indicates whether a finger is currently needed on the sensor for authentication or enrollment operations. The change includes updates to the D- Bus interface definition, Go implementation, mock interface, and configuration mapping.

The property helps applications determine when to prompt users to place their finger on the sensor, improving user experience by providing clear feedback about device readiness state.

Log: Added finger-needed property to fingerprint device interface

Influence:
1. Test that the finger-needed property returns correct boolean values
2. Verify property accessibility through D-Bus interface
3. Check that mock implementation returns proper mock values
4. Test integration with applications that use this property for user prompts
5. Verify property behavior during different device states (idle, scanning, etc.)

feat: 为指纹设备接口添加 finger-needed 属性

在指纹设备 D-Bus 接口中添加了新的只读布尔属性 'finger-needed'。该属性指
示传感器当前是否需要手指进行认证或注册操作。此更改包括更新 D-Bus 接口定
义、Go 实现、模拟接口和配置映射。

该属性帮助应用程序确定何时提示用户将手指放在传感器上，通过提供关于设备就
绪状态的清晰反馈来改善用户体验。

Log: 为指纹设备接口添加 finger-needed 属性

Influence:
1. 测试 finger-needed 属性是否返回正确的布尔值
2. 验证通过 D-Bus 接口访问该属性的能力
3. 检查模拟实现是否返回适当的模拟值
4. 测试与使用此属性进行用户提示的应用程序的集成
5. 验证在不同设备状态（空闲、扫描等）下的属性行为