### PR TITLE
chore: update changelog to 2.0.26

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+golang-github-linuxdeepin-go-dbus-factory (2.0.26) unstable; urgency=medium
+
+  * feat: add finger-needed property to fprint device interface
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 27 Feb 2026 15:06:25 +0800
+
 golang-github-linuxdeepin-go-dbus-factory (2.0.25) unstable; urgency=medium
 
   * feat: add window maximize and unmaximize methods


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.26

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.26
- 目标分支: master
