### PR TITLE
chore: update changelog to 2.0.27

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+golang-github-linuxdeepin-go-dbus-factory (2.0.27) unstable; urgency=medium
+
+  * feat: add proximity sensor interfaces
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 14 May 2026 20:03:22 +0800
+
 golang-github-linuxdeepin-go-dbus-factory (2.0.26) unstable; urgency=medium
 
   * feat: add finger-needed property to fprint device interface


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.27

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.27
- 目标分支: master
