### PR TITLE
chore: update changelog to 2.0.28

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,14 @@
+golang-github-linuxdeepin-go-dbus-factory (2.0.28) unstable; urgency=medium
+
+  * feat: add Tlp mode and short idle support to power management
+  * refactor(eventlog): improve application event reporting
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 04 Jun 2026 19:32:58 +0800
+
 golang-github-linuxdeepin-go-dbus-factory (2.0.27) unstable; urgency=medium
 
   * feat: add proximity sensor interfaces
+  * fix: remove KWin blur from DialogWindow to fix dark theme issue
 
  -- zhangkun <zhangkun2@uniontech.com>  Thu, 14 May 2026 20:03:22 +0800
 


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.28

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.28
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to version 2.0.28 targeting master.