### PR TITLE
chore: bump version to 2.0.30

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+golang-github-linuxdeepin-go-dbus-factory (2.0.30) unstable; urgency=medium
+
+  * feat(session): add AmbientBrightness1 D-Bus factory interface
+
+ -- zhangkun <zhangkun2@uniontech.com>  Tue, 04 Aug 2026 17:05:51 +0800
+
 golang-github-linuxdeepin-go-dbus-factory (2.0.29) unstable; urgency=medium
 
   * fix(daemon): update custom wallpaper dbus interface


### PR DESCRIPTION
update changelog to 2.0.30

Log: update changelog to 2.0.30

## Summary by Sourcery

Build:
- Update Debian packaging changelog to reflect version 2.0.30.