### PR TITLE
refactor: 移除 SetShortIdleState 接口方法

### DIFF
--- a/system/org.deepin.dde.power1/Power.xml
+++ b/system/org.deepin.dde.power1/Power.xml
@@ -58,9 +58,6 @@
         <method name="SetTlpMode">
             <arg name="mode" type="s" direction="in"></arg>
         </method>
-        <method name="SetShortIdleState">
-            <arg name="state" type="b" direction="in"></arg>
-        </method>
         <method name="LockCpuFreq">
             <arg name="governor" type="s" direction="in"></arg>
             <arg name="lockTime" type="i" direction="in"></arg>

--- a/system/org.deepin.dde.power1/auto.go
+++ b/system/org.deepin.dde.power1/auto.go
@@ -48,8 +48,6 @@ type power interface {
 	SetMode(flags dbus.Flags, mode string) error
 	GoSetTlpMode(flags dbus.Flags, ch chan *dbus.Call, mode string) *dbus.Call
 	SetTlpMode(flags dbus.Flags, mode string) error
-	GoSetShortIdleState(flags dbus.Flags, ch chan *dbus.Call, state bool) *dbus.Call
-	SetShortIdleState(flags dbus.Flags, state bool) error
 	GoLockCpuFreq(flags dbus.Flags, ch chan *dbus.Call, governor string, lockTime int32) *dbus.Call
 	LockCpuFreq(flags dbus.Flags, governor string, lockTime int32) error
 	ConnectBatteryDisplayUpdate(cb func(timestamp int64)) (dbusutil.SignalHandlerId, error)
@@ -178,16 +176,6 @@ func (v *interfacePower) GoSetTlpMode(flags dbus.Flags, ch chan *dbus.Call, mode
 
 func (v *interfacePower) SetTlpMode(flags dbus.Flags, mode string) error {
 	return (<-v.GoSetTlpMode(flags, make(chan *dbus.Call, 1), mode).Done).Err
-}
-
-// method SetShortIdleState
-
-func (v *interfacePower) GoSetShortIdleState(flags dbus.Flags, ch chan *dbus.Call, state bool) *dbus.Call {
-	return v.GetObject_().Go_(v.GetInterfaceName_()+".SetShortIdleState", flags, ch, state)
-}
-
-func (v *interfacePower) SetShortIdleState(flags dbus.Flags, state bool) error {
-	return (<-v.GoSetShortIdleState(flags, make(chan *dbus.Call, 1), state).Done).Err
 }
 
 // method LockCpuFreq

--- a/system/org.deepin.dde.power1/auto_mock.go
+++ b/system/org.deepin.dde.power1/auto_mock.go
@@ -180,25 +180,6 @@ func (v *MockInterfacePower) SetTlpMode(flags dbus.Flags, mode string) error {
 	return mockArgs.Error(0)
 }
 
-// method SetShortIdleState
-
-func (v *MockInterfacePower) GoSetShortIdleState(flags dbus.Flags, ch chan *dbus.Call, state bool) *dbus.Call {
-	mockArgs := v.Called(flags, ch, state)
-
-	ret, ok := mockArgs.Get(0).(*dbus.Call)
-	if !ok {
-		panic(fmt.Sprintf("assert: arguments: 0 failed because object wasn't correct type: %v", mockArgs.Get(0)))
-	}
-
-	return ret
-}
-
-func (v *MockInterfacePower) SetShortIdleState(flags dbus.Flags, state bool) error {
-	mockArgs := v.Called(flags, state)
-
-	return mockArgs.Error(0)
-}
-
 // method LockCpuFreq
 
 func (v *MockInterfacePower) GoLockCpuFreq(flags dbus.Flags, ch chan *dbus.Call, governor string, lockTime int32) *dbus.Call {


### PR DESCRIPTION
1. 从 Power.xml 中移除了 SetShortIdleState 的 DBus 方法定义
2. 从 auto.go 的 power 接口及实现中移除了相关的同步与异步调用方法
3. 从 auto_mock.go 测试模拟类中移除了对应的 mock 方法实现
4. 此变更用于清理废弃代码，因为该短空闲状态设置接口在后端已不再使用，移 除它可以保持客户端 DBus 接口定义的整洁，避免无效调用和代码冗余

Influence:
1. 验证电源管理模块其他 DBus 接口的正常调用，如 SetMode、SetTlpMode 和 LockCpuFreq
2. 检查系统运行日志，确认无任何模块尝试调用已移除的 SetShortIdleState 方 法导致 DBus 错误
3. 验证系统电源设置相关 UI 界面能正常打开和操作，未因底层接口变更出现崩 溃或异常卡顿

Task: https://pms.uniontech.com/task-view-393313.html

## Summary by Sourcery

Remove the deprecated SetShortIdleState DBus method from the power service interface and related client bindings.

Enhancements:
- Clean up unused SetShortIdleState method from the Power.xml DBus interface definition and generated power client interface.
- Remove SetShortIdleState mock implementations from the power interface test mocks to reflect the updated DBus API surface.