### PR TITLE
Revert "refactor: 移除 SetShortIdleState 接口方法"

### DIFF
--- a/system/org.deepin.dde.power1/Power.xml
+++ b/system/org.deepin.dde.power1/Power.xml
@@ -58,6 +58,9 @@
         <method name="SetTlpMode">
             <arg name="mode" type="s" direction="in"></arg>
         </method>
+        <method name="SetShortIdleState">
+            <arg name="state" type="b" direction="in"></arg>
+        </method>
         <method name="LockCpuFreq">
             <arg name="governor" type="s" direction="in"></arg>
             <arg name="lockTime" type="i" direction="in"></arg>

--- a/system/org.deepin.dde.power1/auto.go
+++ b/system/org.deepin.dde.power1/auto.go
@@ -48,6 +48,8 @@ type power interface {
 	SetMode(flags dbus.Flags, mode string) error
 	GoSetTlpMode(flags dbus.Flags, ch chan *dbus.Call, mode string) *dbus.Call
 	SetTlpMode(flags dbus.Flags, mode string) error
+	GoSetShortIdleState(flags dbus.Flags, ch chan *dbus.Call, state bool) *dbus.Call
+	SetShortIdleState(flags dbus.Flags, state bool) error
 	GoLockCpuFreq(flags dbus.Flags, ch chan *dbus.Call, governor string, lockTime int32) *dbus.Call
 	LockCpuFreq(flags dbus.Flags, governor string, lockTime int32) error
 	ConnectBatteryDisplayUpdate(cb func(timestamp int64)) (dbusutil.SignalHandlerId, error)
@@ -176,6 +178,16 @@ func (v *interfacePower) GoSetTlpMode(flags dbus.Flags, ch chan *dbus.Call, mode
 
 func (v *interfacePower) SetTlpMode(flags dbus.Flags, mode string) error {
 	return (<-v.GoSetTlpMode(flags, make(chan *dbus.Call, 1), mode).Done).Err
+}
+
+// method SetShortIdleState
+
+func (v *interfacePower) GoSetShortIdleState(flags dbus.Flags, ch chan *dbus.Call, state bool) *dbus.Call {
+	return v.GetObject_().Go_(v.GetInterfaceName_()+".SetShortIdleState", flags, ch, state)
+}
+
+func (v *interfacePower) SetShortIdleState(flags dbus.Flags, state bool) error {
+	return (<-v.GoSetShortIdleState(flags, make(chan *dbus.Call, 1), state).Done).Err
 }
 
 // method LockCpuFreq

--- a/system/org.deepin.dde.power1/auto_mock.go
+++ b/system/org.deepin.dde.power1/auto_mock.go
@@ -180,6 +180,25 @@ func (v *MockInterfacePower) SetTlpMode(flags dbus.Flags, mode string) error {
 	return mockArgs.Error(0)
 }
 
+// method SetShortIdleState
+
+func (v *MockInterfacePower) GoSetShortIdleState(flags dbus.Flags, ch chan *dbus.Call, state bool) *dbus.Call {
+	mockArgs := v.Called(flags, ch, state)
+
+	ret, ok := mockArgs.Get(0).(*dbus.Call)
+	if !ok {
+		panic(fmt.Sprintf("assert: arguments: 0 failed because object wasn't correct type: %v", mockArgs.Get(0)))
+	}
+
+	return ret
+}
+
+func (v *MockInterfacePower) SetShortIdleState(flags dbus.Flags, state bool) error {
+	mockArgs := v.Called(flags, state)
+
+	return mockArgs.Error(0)
+}
+
 // method LockCpuFreq
 
 func (v *MockInterfacePower) GoLockCpuFreq(flags dbus.Flags, ch chan *dbus.Call, governor string, lockTime int32) *dbus.Call {


### PR DESCRIPTION
This reverts commit 59afe07291cee54497d91182c866f21e20ed0dce.

## Summary by Sourcery

Enhancements:
- Restore the SetShortIdleState D-Bus power interface and its generated client and mock support.